### PR TITLE
Script Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,25 @@ Anyway, it is simple, minimalistic, easy to read and easy to tune for your needs
 
 Read more: http://www.artembutusov.com/gentoo-linux-quick-installer-script/
 
-## Contribution
-
-For almost any change please consider doing a few tests below.
-
-Images should be bootable and should allow to login using root password-auth or password-less auth via SSH.
+## Usage
 
 ```shell
 # livecd kernel with root password
 USE_LIVECD_KERNEL=1 ROOT_PASSWORD=Gentoo123 ./gentoo-quick-installer.sh
 
-# Compiled kernel with ssh public key
+# Gentoo binary kernel with ssh public key
 USE_LIVECD_KERNEL=0 SSH_PUBLIC_KEY=$(cat id_rsa.pub) ./gentoo-quick-installer.sh
 ```
+
+## Limitations
+* Does not work with UEFI. Legacy BIOS and VM use only.
+* Does not work with GPT partitions. MSDOS/MBR only.
+
+## Contribution
+
+For almost any change please consider doing a few tests using both commands above.
+
+Images should be bootable and should allow to login using root password-auth or password-less auth via SSH.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Read more: http://www.artembutusov.com/gentoo-linux-quick-installer-script/
 ## Usage
 
 ```shell
-# livecd kernel with root password
-USE_LIVECD_KERNEL=1 ROOT_PASSWORD=Gentoo123 ./gentoo-quick-installer.sh
+# Bare metal install on /dev/sda with root password:
+ROOT_PASSWORD=Gentoo123 ./gentoo-quick-installer.sh
 
-# Gentoo binary kernel with ssh public key
-USE_LIVECD_KERNEL=0 SSH_PUBLIC_KEY=$(cat id_rsa.pub) ./gentoo-quick-installer.sh
+# Remote VM server install with ssh RSA public key:
+TARGET_DISK=/dev/vda SSH_PUBLIC_KEY=$(cat id_rsa.pub) ./gentoo-quick-installer.sh
 ```
 
 ## Limitations

--- a/gentoo-quick-installer.sh
+++ b/gentoo-quick-installer.sh
@@ -138,12 +138,12 @@ END
 
 echo "### Mounting proc/sys/dev..."
 
-mount -t proc none /mnt/gentoo/proc
-mount -t sysfs none /mnt/gentoo/sys
+mount --types proc /proc /mnt/gentoo/proc
+mount --rbind /sys /mnt/gentoo/sys
 mount --rbind /dev /mnt/gentoo/dev
-mount -o bind /dev/pts /mnt/gentoo/dev/pts
-mount -o bind /dev/shm /mnt/gentoo/dev/shm
 mount --bind /run /mnt/gentoo/run
+
+echo "### Fixing possible LiveCD issues..."
 test -L /dev/shm && rm /dev/shm && mkdir /dev/shm
 mount --types tmpfs --options nosuid,nodev,noexec shm /dev/shm
 chmod 1777 /dev/shm /run/shm

--- a/gentoo-quick-installer.sh
+++ b/gentoo-quick-installer.sh
@@ -177,7 +177,6 @@ if [ "$USE_LIVECD_KERNEL" = 0 ]; then
     
     emerge sys-kernel/linux-firmware installkernel-gentoo
     emerge virtual/dist-kernel sys-kernel/gentoo-kernel-bin
-    emerge sys-kernel/genkernel
 fi
 
 echo "### Installing bootloader..."

--- a/gentoo-quick-installer.sh
+++ b/gentoo-quick-installer.sh
@@ -37,7 +37,7 @@ GENTOO_ARCH="amd64"
 # amd64-hardened-selinux-openrc, amd64-musl, md64-musl-hardened, 
 # amd64-hardened-selinux-openrc, amd64-hardened-openrc, 
 # amd64-hardened-nomultilib-selinux-openrc, and amd64-hardened-nomultilib-openrc
-GENTOO_STAGE3="	amd64-openrc"
+GENTOO_STAGE3="amd64-openrc"
 
 # Default is set for virtual machines.
 # /dev/sda is standard for most IDE/SATA drives.

--- a/gentoo-quick-installer.sh
+++ b/gentoo-quick-installer.sh
@@ -16,6 +16,12 @@
 # USE_LIVECD_KERNEL - 1 to use livecd kernel (saves time) or 0 to build kernel (takes time)
 # SSH_PUBLIC_KEY - ssh public key, pass contents of `cat ~/.ssh/id_rsa.pub` for example
 # ROOT_PASSWORD - root password, only SSH key-based authentication will work if not set
+#
+# livecd kernel with root password
+# USE_LIVECD_KERNEL=1 ROOT_PASSWORD=Gentoo123 ./gentoo-quick-installer.sh
+#
+# Compiled kernel with ssh public key
+# USE_LIVECD_KERNEL=0 SSH_PUBLIC_KEY=$(cat id_rsa.pub) ./gentoo-quick-installer.sh
 ##
 
 set -e
@@ -149,20 +155,18 @@ source /etc/profile
 
 echo "### Installing portage..."
 
-mv /etc/portage/make.conf /etc/portage/default
-mkdir /etc/portage/make.conf
-mv /etc/portage/default /etc/portage/make.conf
-echo "PORTAGE_BINHOST=\"https://mirror.yandex.ru/calculate/grp/x86_64\""
 mkdir -p /etc/portage/repos.conf
 cp -f /usr/share/portage/config/repos.conf /etc/portage/repos.conf/gentoo.conf
 emerge-webrsync
+mv /etc/portage/make.conf /etc/portage/default
+mkdir /etc/portage/make.conf
+mv /etc/portage/default /etc/portage/make.conf
+echo "PORTAGE_BINHOST=\"https://mirror.yandex.ru/calculate/grp/x86_64\"" >> /etc/portage/make.conf/binhost
 echo "ACCEPT_LICENSE=\"*\"" >> /etc/portage/make.conf/default
 emerge -G eix
 eix-sync
 
 echo "### Installing kernel binary..."
-
-echo "ACCEPT_LICENSE=\"*\"" >> /etc/portage/make.conf/default
 
 if [ "$USE_LIVECD_KERNEL" = 0 ]; then
     echo "### Installing kernel..."

--- a/gentoo-quick-installer.sh
+++ b/gentoo-quick-installer.sh
@@ -208,7 +208,7 @@ echo "### Configuring network..."
 
 ln -s /etc/init.d/net.lo /etc/init.d/net.eth0
 rc-update add net.eth0 default
-emerge -G net-misc/dhcpcd
+emerge -g net-misc/dhcpcd
 
 if [ -z "$ROOT_PASSWORD" ]; then
     echo "### Removing root password..."

--- a/gentoo-quick-installer.sh
+++ b/gentoo-quick-installer.sh
@@ -205,7 +205,7 @@ echo "### Configuring network..."
 
 ln -s /etc/init.d/net.lo /etc/init.d/net.eth0
 rc-update add net.eth0 default
-emerge -g net-misc/dhcpcd
+emerge net-misc/dhcpcd
 
 if [ -z "$ROOT_PASSWORD" ]; then
     echo "### Removing root password..."

--- a/gentoo-quick-installer.sh
+++ b/gentoo-quick-installer.sh
@@ -127,9 +127,13 @@ echo "### Mounting proc/sys/dev..."
 
 mount -t proc none /mnt/gentoo/proc
 mount -t sysfs none /mnt/gentoo/sys
-mount -o bind /dev /mnt/gentoo/dev
+mount --rbind /dev /mnt/gentoo/dev
 mount -o bind /dev/pts /mnt/gentoo/dev/pts
 mount -o bind /dev/shm /mnt/gentoo/dev/shm
+mount --bind /run /mnt/gentoo/run
+test -L /dev/shm && rm /dev/shm && mkdir /dev/shm
+mount --types tmpfs --options nosuid,nodev,noexec shm /dev/shm
+chmod 1777 /dev/shm /run/shm
 
 echo "### Changing root..."
 
@@ -152,6 +156,9 @@ echo "PORTAGE_BINHOST=\"https://mirror.yandex.ru/calculate/grp/x86_64\""
 mkdir -p /etc/portage/repos.conf
 cp -f /usr/share/portage/config/repos.conf /etc/portage/repos.conf/gentoo.conf
 emerge-webrsync
+echo "ACCEPT_LICENSE=\"*\"" >> /etc/portage/make.conf/default
+emerge -G eix
+eix-sync
 
 echo "### Installing kernel binary..."
 
@@ -196,6 +203,7 @@ echo "### Configuring network..."
 
 ln -s /etc/init.d/net.lo /etc/init.d/net.eth0
 rc-update add net.eth0 default
+emerge -G net-misc/dhcpcd
 
 if [ -z "$ROOT_PASSWORD" ]; then
     echo "### Removing root password..."


### PR DESCRIPTION
* Now works on non-Gentoo LiveCD's.
* GENTOO_STAGE3 profile changed to "amd64-openrc"
* TARGET_DISK is now /dev/vda, because it should be.
* /boot is 256M now.
* Using Calculate Linux as optional binhost for faster install.
* Genkernel is no longer needed - installing binary kernel packages.
* make.conf should be a directory.
* Licenses needed to be accepted.
* dhcpcd added so network doesn't fail on reboot.
* ~~eix added/synced~~ 